### PR TITLE
fix: text field input fast bug

### DIFF
--- a/src/Masa.Blazor/Components/TextArea/MTextArea.cs
+++ b/src/Masa.Blazor/Components/TextArea/MTextArea.cs
@@ -1,4 +1,5 @@
 ﻿using BlazorComponent.Web;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace Masa.Blazor
 {
@@ -51,6 +52,14 @@ namespace Masa.Blazor
             {
                 await CalculateInputHeight();
             }
+        }
+
+        public override async Task HandleOnKeyDownAsync(KeyboardEventArgs args)
+        {
+            await ChangeValue();
+
+            if (OnKeyDown.HasDelegate)
+                await OnKeyDown.InvokeAsync(args);
         }
 
         private async Task CalculateInputHeight()

--- a/src/Masa.Blazor/Components/TextField/MTextField.cs
+++ b/src/Masa.Blazor/Components/TextField/MTextField.cs
@@ -702,8 +702,6 @@ namespace Masa.Blazor
 
         public async Task HandleOnKeyUpAsync(KeyboardEventArgs args)
         {
-            await ChangeValue();
-
             if (OnKeyUp.HasDelegate)
                 await OnKeyUp.InvokeAsync();
         }
@@ -776,6 +774,16 @@ namespace Masa.Blazor
 
         public virtual async Task HandleOnKeyDownAsync(KeyboardEventArgs args)
         {
+            await Task.Yield();
+
+            if (args.Key == "Enter")
+            {
+                await ChangeValue(true);
+            }
+            else
+            {
+                await ChangeValue();
+            }
 
             if (OnKeyDown.HasDelegate)
             {

--- a/src/Masa.Blazor/Masa.Blazor.csproj
+++ b/src/Masa.Blazor/Masa.Blazor.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="6.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.0" />
-		<PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.80.3" />
+		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.80.3" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
when use bind-value in text field and input fast, the bind-value will not change