### PR TITLE
fix(MSelect): fix when TItemValue is struct type, default select value error

### DIFF
--- a/src/Masa.Blazor/Components/Select/MSelect.cs
+++ b/src/Masa.Blazor/Components/Select/MSelect.cs
@@ -894,6 +894,11 @@ namespace Masa.Blazor
 
         protected virtual void SetSelectedItems()
         {
+            if(ItemValue == null)
+            {
+                return;
+            }
+
             var selectedItems = new List<TItem>();
 
             var values = InternalValues;
@@ -902,7 +907,7 @@ namespace Masa.Blazor
             {
                 var item = AllItems.FirstOrDefault(v => EqualityComparer<TItemValue>.Default.Equals(value, GetValue(v)));
 
-                if (!item.Equals(default(TItemValue)))
+                if (item is not null && !item.Equals(default(TItem)))
                 {
                     selectedItems.Add(item);
                 }

--- a/src/Masa.Blazor/Components/Select/MSelect.cs
+++ b/src/Masa.Blazor/Components/Select/MSelect.cs
@@ -731,7 +731,7 @@ namespace Masa.Blazor
         {
             var firstItem = ComputedItemsIfHideSelected.FirstOrDefault();
 
-            if (firstItem.Equals(default(TItem))) return;
+            if (firstItem is null || firstItem.Equals(default(TItem))) return;
 
             MenuListIndex = 0;
 

--- a/src/Masa.Blazor/Components/Select/MSelect.cs
+++ b/src/Masa.Blazor/Components/Select/MSelect.cs
@@ -731,7 +731,7 @@ namespace Masa.Blazor
         {
             var firstItem = ComputedItemsIfHideSelected.FirstOrDefault();
 
-            if (firstItem is null) return;
+            if (firstItem.Equals(default(TItem))) return;
 
             MenuListIndex = 0;
 
@@ -902,7 +902,7 @@ namespace Masa.Blazor
             {
                 var item = AllItems.FirstOrDefault(v => EqualityComparer<TItemValue>.Default.Equals(value, GetValue(v)));
 
-                if (item is not null)
+                if (!item.Equals(default(TItemValue)))
                 {
                     selectedItems.Add(item);
                 }


### PR DESCRIPTION
fix: fix when TItemValue is struct type, default select an empty value
