### PR TITLE
🚸 feat(ECharts): improve the way to update the theme

### DIFF
--- a/src/Docs/Masa.Blazor.Docs/Examples/components/echarts/Dark.razor
+++ b/src/Docs/Masa.Blazor.Docs/Examples/components/echarts/Dark.razor
@@ -1,5 +1,5 @@
 ﻿<div class="d-flex flex-column align-center justify-center">
-    <MECharts Option="option" Width="@("100%")" Dark></MECharts>
+    <MECharts Option="option" Width="@("100%")" MinHeight="300" Dark></MECharts>
 </div>
 
 @code{

--- a/src/Docs/Masa.Blazor.Docs/Examples/components/echarts/Locale.razor
+++ b/src/Docs/Masa.Blazor.Docs/Examples/components/echarts/Locale.razor
@@ -5,6 +5,7 @@
     <MECharts Option="option"
               InitOptions="opt => opt.Locale = locale"
               Width="@("100%")"
+              MinHeight="300"
               @ref="echarts">
     </MECharts>
 

--- a/src/Docs/Masa.Blazor.Docs/Examples/components/echarts/Theme.razor
+++ b/src/Docs/Masa.Blazor.Docs/Examples/components/echarts/Theme.razor
@@ -1,7 +1,7 @@
 ﻿<div class="d-flex flex-column align-center justify-center">
-    <MECharts Option="option" Theme="@theme" Width="@("100%")" @ref="echarts"></MECharts>
+    <MECharts Option="option" Theme="@theme" Width="@("100%")" MinHeight="300"></MECharts>
 
-    <MRadioGroup TValue="string" Value="theme" ValueChanged="SetTheme" Row>
+    <MRadioGroup TValue="string" @bind-Value="theme" Row>
         <MRadio Label="default"
                 Value="@("")">
         </MRadio>
@@ -18,7 +18,6 @@
 </div>
 
 @code{
-    private MECharts echarts;
     private string theme = string.Empty;
 
     private object option = new
@@ -49,15 +48,5 @@
             }
         }
     };
-
-    private async Task SetTheme(string val)
-    {
-        if (theme != null && echarts != null)
-        {
-            await echarts.DisposeECharts();
-        }
-
-        theme = val;
-    }
 
 }

--- a/src/Docs/Masa.Blazor.Docs/wwwroot/pages/components/echarts/en-US.md
+++ b/src/Docs/Masa.Blazor.Docs/wwwroot/pages/components/echarts/en-US.md
@@ -6,8 +6,6 @@ tag: js-proxy
 
 ## Usage
 
-Examples
-
 <echarts-usage></echarts-usage>
 
 <app-alert type="info" content='You need to reference the package of ECharts before using it: `<script src="https://cdn.masastack.com/npm/echarts/5.1.1/echarts.min.js"></script>`.'></app-alert>
@@ -39,5 +37,3 @@ Specify the locale. For more information, please refer to ECharts official docum
 Specify the theme. Light and dark themes are supported by default. You can use [custom themes](https://echarts.apache.org/handbook/en/concepts/style/#theme). In this example, the **vintage** theme can be set after importing the vintage.js file in HTML.
 
 <masa-example file="Examples.components.echarts.Theme"></masa-example>
-
-

--- a/src/Docs/Masa.Blazor.Docs/wwwroot/pages/components/echarts/zh-CN.md
+++ b/src/Docs/Masa.Blazor.Docs/wwwroot/pages/components/echarts/zh-CN.md
@@ -6,8 +6,6 @@ tag: js-proxy
 
 ## 使用
 
-图表使用
-
 <echarts-usage></echarts-usage>
 
 <app-alert type="info" content='使用前需要先引用ECharts的包：`<script src="https://cdn.masastack.com/npm/echarts/5.1.1/echarts.min.js"></script>`。'></app-alert>
@@ -39,5 +37,3 @@ tag: js-proxy
 指定使用的主题，默认支持亮和暗主题。 你可以使用[自定义主题](https://echarts.apache.org/handbook/zh/concepts/style/#%E9%A2%9C%E8%89%B2%E4%B8%BB%E9%A2%98%EF%BC%88theme%EF%BC%89)，例如本示例，在HTML引入vintage.js文件后可以设置**vintage**主题。
 
 <masa-example file="Examples.components.echarts.Locale"></masa-example>
-
-

--- a/src/Docs/Masa.Docs.Shared/wwwroot/locale/en-US.json
+++ b/src/Docs/Masa.Docs.Shared/wwwroot/locale/en-US.json
@@ -121,7 +121,7 @@
   "dividers": "Dividers",
   "drag-zone": "Drag zone",
   "drawers": "Drawers",
-  "echarts": "Echarts",
+  "echarts": "ECharts",
   "editors": "Editors",
   "error-handler": "Error handler",
   "expansion-panels": "Expansion panels",

--- a/src/Docs/Masa.Docs.Shared/wwwroot/locale/zh-CN.json
+++ b/src/Docs/Masa.Docs.Shared/wwwroot/locale/zh-CN.json
@@ -136,7 +136,7 @@
   "dividers": "Dividers（分割线）",
   "drag-zone": "Drag zone（拖放）",
   "drawers": "Drawers（抽屉）",
-  "echarts": "Echarts（图表）",
+  "echarts": "ECharts（图表）",
   "editors": "Editors（富文本编辑器）",
   "error-handler": "Error handler（异常处理）",
   "expansion-panels": "Expansion panels（扩展面板）",

--- a/src/Masa.Blazor/Components/ECharts/MECharts.razor.cs
+++ b/src/Masa.Blazor/Components/ECharts/MECharts.razor.cs
@@ -49,6 +49,7 @@ public partial class MECharts : BDomComponentBase, IAsyncDisposable
     private IJSObjectReference _echarts;
     private bool _isEChartsDisposed = false;
     private object _prevOption;
+    private string _prevComputedTheme;
 
     public string ComputedTheme
     {
@@ -60,6 +61,16 @@ public partial class MECharts : BDomComponentBase, IAsyncDisposable
             }
 
             if (Dark)
+            {
+                return "dark";
+            }
+
+            if (Light)
+            {
+                return "light";
+            }
+
+            if (CascadingIsDark)
             {
                 return "dark";
             }
@@ -83,11 +94,20 @@ public partial class MECharts : BDomComponentBase, IAsyncDisposable
             });
     }
 
-    protected override void OnParametersSet()
+    protected override async Task OnParametersSetAsync()
     {
+        await base.OnParametersSetAsync();
+
         InitOptions?.Invoke(DefaultInitOptions);
 
         DefaultInitOptions.Locale ??= I18n.Culture.TwoLetterISOLanguageName.ToUpperInvariant();
+
+        if (_prevComputedTheme != ComputedTheme)
+        {
+            _prevComputedTheme = ComputedTheme;
+
+            await DisposeECharts();
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)


### PR DESCRIPTION
Now ECharts does not need to manually call `DisposeECharts` to update the theme, just the parameters `Light`, `Dark`, `Theme` or cascaded `IsDark`. Also resolved #246.

