### PR TITLE
Add MMap component (only map roaming supported by now).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,6 @@ packages/
 
 # source code text of Examples in Docs
 src/Docs/**/wwwroot/pages/**/examples
+
+# source code text of test code
+src/Masa.Blazor.Playground/*

--- a/src/Masa.Blazor/Components/Counter/MCounter.cs
+++ b/src/Masa.Blazor/Components/Counter/MCounter.cs
@@ -2,8 +2,6 @@
 {
     public class MCounter : BCounter
     {
-
-
         protected override void SetComponentClass()
         {
             CssProvider

--- a/src/Masa.Blazor/Components/Map/MMap.cs
+++ b/src/Masa.Blazor/Components/Map/MMap.cs
@@ -1,0 +1,25 @@
+﻿using BlazorComponent;
+
+namespace Masa.Blazor
+{
+    public partial class MMap : BMap, IThemeable
+    {
+        protected override void SetComponentClass()
+        {
+            base.SetComponentClass();
+
+            CssProvider
+                .Apply(cssBuilder =>
+                {
+                    cssBuilder
+                        .Add("map-base")
+                        .AddTheme(IsDark);
+                }, styleBuilder =>
+                {
+                    styleBuilder
+                        .AddWidth(Width)
+                        .AddHeight(Height);
+                });
+        }
+    }
+}

--- a/src/Masa.Blazor/Components/Map/MMap.cs
+++ b/src/Masa.Blazor/Components/Map/MMap.cs
@@ -12,7 +12,7 @@ namespace Masa.Blazor
                 .Apply(cssBuilder =>
                 {
                     cssBuilder
-                        .Add("map-base")
+                        .Add("m-bmap")
                         .AddTheme(IsDark);
                 }, styleBuilder =>
                 {


### PR DESCRIPTION
# Description

Add MMap component. Only map roaming supported by now, more feature will be supported in the future. 

MMap uses free BaiduMap services. To use MMap, register your ServiceKey (ak) [here](https://lbsyun.baidu.com/index.php?title=jspopularGL/guide/getkey).

Once you‘ve got your key, you can add a map in your blazor app like:

`<MMap ServiceKey="your-key" Width="500" Height="500"/>`
