### PR TITLE
feat: Support for dynamic theme modification

### DIFF
--- a/src/Docs/Masa.Blazor.Docs/Examples/components/application/DynamicallyModifyTheme.razor
+++ b/src/Docs/Masa.Blazor.Docs/Examples/components/application/DynamicallyModifyTheme.razor
@@ -1,4 +1,4 @@
-﻿<MSwitch Value="IsDark" TValue="bool" ValueChanged="IsDarkChanged" Label="@(IsDark?"深色模式":"浅色模式")"/>
+﻿<MSwitch Value="IsDark" TValue="bool" ValueChanged="IsDarkChanged" Label="@(IsDark?"Dark":"Light")"/>
 
 @code {
     [Inject]

--- a/src/Docs/Masa.Blazor.Docs/Examples/components/application/DynamicallyModifyTheme.razor
+++ b/src/Docs/Masa.Blazor.Docs/Examples/components/application/DynamicallyModifyTheme.razor
@@ -1,0 +1,25 @@
+﻿<MSwitch Value="IsDark" TValue="bool" ValueChanged="IsDarkChanged" Label="@(IsDark?"深色模式":"浅色模式")"/>
+
+@code {
+    [Inject]
+    public MasaBlazor MasaBlazor { get; set; }
+
+    bool IsDark { get; set; }
+
+    protected override Task OnInitializedAsync()
+    {
+        IsDark = MasaBlazor?.Theme?.Dark ?? false;
+        return base.OnInitializedAsync();
+    }
+
+    public Task IsDarkChanged(bool isDark)
+    {
+        IsDark = isDark;
+        var theme = MasaBlazor.Theme;
+        theme.Dark = isDark;
+
+        MasaBlazor.Theme = theme;
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Docs/Masa.Blazor.Docs/Masa.Blazor.Docs.csproj
+++ b/src/Docs/Masa.Blazor.Docs/Masa.Blazor.Docs.csproj
@@ -21,9 +21,6 @@
     <ProjectReference Include="..\Masa.Docs.Core\Masa.Docs.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ExamplesSourceFile Include="Examples\**\*.razor" />
-  </ItemGroup>
 
   <ItemGroup>
     <ExamplesSourceFile Remove="Examples\components\application\DynamicallyModifyTheme.razor" />

--- a/src/Docs/Masa.Blazor.Docs/Masa.Blazor.Docs.csproj
+++ b/src/Docs/Masa.Blazor.Docs/Masa.Blazor.Docs.csproj
@@ -21,11 +21,10 @@
     <ProjectReference Include="..\Masa.Docs.Core\Masa.Docs.Core.csproj" />
   </ItemGroup>
 
-
   <ItemGroup>
-    <ExamplesSourceFile Remove="Examples\components\application\DynamicallyModifyTheme.razor" />
+    <ExamplesSourceFile Include="Examples\**\*.razor" />
   </ItemGroup>
-
+  
   <Target Name="CopyExmaplesToTxt" AfterTargets="Build">
     <Copy SourceFiles="@(ExamplesSourceFile)" DestinationFiles="wwwroot\pages\%(RecursiveDir)\examples\%(Filename).txt" />
   </Target>

--- a/src/Docs/Masa.Blazor.Docs/Masa.Blazor.Docs.csproj
+++ b/src/Docs/Masa.Blazor.Docs/Masa.Blazor.Docs.csproj
@@ -25,6 +25,10 @@
     <ExamplesSourceFile Include="Examples\**\*.razor" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ExamplesSourceFile Remove="Examples\components\application\DynamicallyModifyTheme.razor" />
+  </ItemGroup>
+
   <Target Name="CopyExmaplesToTxt" AfterTargets="Build">
     <Copy SourceFiles="@(ExamplesSourceFile)" DestinationFiles="wwwroot\pages\%(RecursiveDir)\examples\%(Filename).txt" />
   </Target>

--- a/src/Docs/Masa.Blazor.Docs/Masa.Blazor.Docs.csproj
+++ b/src/Docs/Masa.Blazor.Docs/Masa.Blazor.Docs.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <ExamplesSourceFile Include="Examples\**\*.razor" />
   </ItemGroup>
-  
+
   <Target Name="CopyExmaplesToTxt" AfterTargets="Build">
     <Copy SourceFiles="@(ExamplesSourceFile)" DestinationFiles="wwwroot\pages\%(RecursiveDir)\examples\%(Filename).txt" />
   </Target>

--- a/src/Docs/Masa.Blazor.Docs/wwwroot/pages/components/application/en-US.md
+++ b/src/Docs/Masa.Blazor.Docs/wwwroot/pages/components/application/en-US.md
@@ -95,4 +95,27 @@ You can access these values by referencing the `Application` property.
 
 <app-alert type="error" content="In order for your application to work properly, you must wrap it in a **MApp** component. "></app-alert>
 
+## Application Theme
 
+The theme of Masa Blazor can be customized, including various default colors...
+
+Modify the code to add Masa.Blazor related services in Program.cs to set a default theme
+
+```csharp
+builder.Services.AddMasaBlazor(options =>
+{
+    options.ConfigureTheme(theme =>
+    {
+        theme.Themes.Light.Primary = "#4318FF";
+        theme.Themes.Light.Secondary = "#5CBBF6";
+        theme.Themes.Light.Accent = "#005CAF";
+        theme.Themes.Light.UserDefined["Tertiary"] = "#e57373";
+    });
+})
+```
+
+### Dynamically modify the theme
+
+You can access theme settings by referencing the app properties of the **Theme** object, or you can modify theme settings by reassigning values
+
+<masa-example file="Examples.components.application.DynamicallyModifyTheme"></masa-example>

--- a/src/Docs/Masa.Blazor.Docs/wwwroot/pages/components/application/zh-CN.md
+++ b/src/Docs/Masa.Blazor.Docs/wwwroot/pages/components/application/zh-CN.md
@@ -86,3 +86,27 @@ double Top { get; }
 
 <app-alert type="error" content="为了让你的应用正常工作，你必须将其包裹在 **MApp** 组件中。 该组件是确保正确的跨浏览器兼容性的必要条件。 MASA Blazor 不支持在一个页面上有多个孤立的 
 Masa.Blazor 实例。 **MApp** 可以存在于你的应用主体的任何地方，但是只能有一个，而且它必须是所有 MASA Blazor 组件的祖先节点。"></app-alert>
+
+## 应用主题
+
+可以自定义 Masa Blazor 的主题，包括各种默认颜色......
+
+在 Program.cs 中修改添加 Masa.Blazor 相关服务的代码，即可设置默认主题
+```csharp
+builder.Services.AddMasaBlazor(options =>
+{
+    options.ConfigureTheme(theme =>
+    {
+        theme.Themes.Light.Primary = "#4318FF";
+        theme.Themes.Light.Secondary = "#5CBBF6";
+        theme.Themes.Light.Accent = "#005CAF";
+        theme.Themes.Light.UserDefined["Tertiary"] = "#e57373";
+    });
+})
+```
+
+### 动态修改主题
+
+你可以通过引用 **Theme** 对象的应用属性来访问主题设置，也可以通过重新赋值来修改主题设置
+
+<masa-example file="Examples.components.application.DynamicallyModifyTheme"></masa-example>

--- a/src/Masa.Blazor.NewDocs.sln
+++ b/src/Masa.Blazor.NewDocs.sln
@@ -25,7 +25,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Masa.Stack.Docs", "MASA.Doc
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Masa.Framework.Docs", "MASA.Docs\src\Masa.Framework.Docs\Masa.Framework.Docs.csproj", "{B5AB302E-2357-467E-B085-E64892E2814F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Masa.Blazor.SourceGenerator.Docs.ApiGenerator", "Masa.Blazor.SourceGenerator.Docs.ApiGenerator\Masa.Blazor.SourceGenerator.Docs.ApiGenerator.csproj", "{7F566224-2D3E-4F20-9B9D-FA154D91C3C9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Masa.Blazor.SourceGenerator.Docs.ApiGenerator", "Masa.Blazor.SourceGenerator.Docs.ApiGenerator\Masa.Blazor.SourceGenerator.Docs.ApiGenerator.csproj", "{7F566224-2D3E-4F20-9B9D-FA154D91C3C9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Masa.Blazor.NewDocs.sln
+++ b/src/Masa.Blazor.NewDocs.sln
@@ -25,7 +25,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Masa.Stack.Docs", "MASA.Doc
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Masa.Framework.Docs", "MASA.Docs\src\Masa.Framework.Docs\Masa.Framework.Docs.csproj", "{B5AB302E-2357-467E-B085-E64892E2814F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Masa.Blazor.SourceGenerator.Docs.ApiGenerator", "Masa.Blazor.SourceGenerator.Docs.ApiGenerator\Masa.Blazor.SourceGenerator.Docs.ApiGenerator.csproj", "{7F566224-2D3E-4F20-9B9D-FA154D91C3C9}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Masa.Blazor.SourceGenerator.Docs.ApiGenerator", "Masa.Blazor.SourceGenerator.Docs.ApiGenerator\Masa.Blazor.SourceGenerator.Docs.ApiGenerator.csproj", "{7F566224-2D3E-4F20-9B9D-FA154D91C3C9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Masa.Blazor/Components/App/MApp.cs
+++ b/src/Masa.Blazor/Components/App/MApp.cs
@@ -52,7 +52,7 @@ namespace Masa.Blazor
         {
             var themeOptions = theme.Dark ? theme.Themes.Dark : theme.Themes.Light;
             Dark = theme.Dark;
-            Styles = ThemeCssBuilder.Build(themeOptions);
+            ThemeStyleMarkups = ThemeCssBuilder.Build(themeOptions);
             StateHasChanged();
         }
 

--- a/src/Masa.Blazor/Components/App/MApp.cs
+++ b/src/Masa.Blazor/Components/App/MApp.cs
@@ -41,15 +41,15 @@ namespace Masa.Blazor
 
         protected override Task OnInitializedAsync()
         {
-            MasaBlazor.OnThemeChange -= MasaBlazor_OnThemeChange;
-            MasaBlazor.OnThemeChange += MasaBlazor_OnThemeChange;
+            MasaBlazor.OnThemeChange -= OnThemeChange;
+            MasaBlazor.OnThemeChange += OnThemeChange;
 
-            MasaBlazor_OnThemeChange(MasaBlazor.Theme);
+            OnThemeChange(MasaBlazor.Theme);
 
             return base.OnInitializedAsync();
         }
 
-        private void MasaBlazor_OnThemeChange(Theme theme)
+        private void OnThemeChange(Theme theme)
         {
             var themeOptions = theme.Dark ? theme.Themes.Dark : theme.Themes.Light;
             Dark = theme.Dark;

--- a/src/Masa.Blazor/Components/App/MApp.cs
+++ b/src/Masa.Blazor/Components/App/MApp.cs
@@ -1,4 +1,3 @@
-﻿using BlazorComponent;
 using BlazorComponent.Web;
 using Masa.Blazor.Popup.Components;
 

--- a/src/Masa.Blazor/Components/App/MApp.cs
+++ b/src/Masa.Blazor/Components/App/MApp.cs
@@ -1,4 +1,5 @@
-﻿using BlazorComponent.Web;
+﻿using BlazorComponent;
+using BlazorComponent.Web;
 using Masa.Blazor.Popup.Components;
 
 namespace Masa.Blazor
@@ -40,11 +41,20 @@ namespace Masa.Blazor
 
         protected override Task OnInitializedAsync()
         {
-            var themeOptions = IsDark ? MasaBlazor.Theme.Themes.Dark : MasaBlazor.Theme.Themes.Light;
+            MasaBlazor.OnThemeChange -= MasaBlazor_OnThemeChange;
+            MasaBlazor.OnThemeChange += MasaBlazor_OnThemeChange;
 
-            HeadJsInterop.InsertAdjacentHTML("beforeend", ThemeCssBuilder.Build(themeOptions));
+            MasaBlazor_OnThemeChange(MasaBlazor.Theme);
 
             return base.OnInitializedAsync();
+        }
+
+        private void MasaBlazor_OnThemeChange(Theme theme)
+        {
+            var themeOptions = theme.Dark ? theme.Themes.Dark : theme.Themes.Light;
+            Dark = theme.Dark;
+            Styles = ThemeCssBuilder.Build(themeOptions);
+            StateHasChanged();
         }
 
         protected override void SetComponentClass()

--- a/src/Masa.Blazor/Services/MasaBlazor.cs
+++ b/src/Masa.Blazor/Services/MasaBlazor.cs
@@ -37,7 +37,7 @@
             get { return _theme; }
             set
             {
-                    _theme = value;
+                _theme = value;
                 OnThemeChange?.Invoke(_theme);
                
             }

--- a/src/Masa.Blazor/Services/MasaBlazor.cs
+++ b/src/Masa.Blazor/Services/MasaBlazor.cs
@@ -6,6 +6,7 @@
     public class MasaBlazor
     {
         private bool _rtl;
+        private Theme _theme;
 
         public MasaBlazor(Breakpoint breakpoint, Application application, Theme theme)
         {
@@ -31,8 +32,19 @@
 
         public Breakpoint Breakpoint { get; }
 
-        public Theme Theme { get; }
+        public Theme Theme
+        {
+            get { return _theme; }
+            set
+            {
+                    _theme = value;
+                OnThemeChange?.Invoke(_theme);
+               
+            }
+        }
 
         public event Action<bool> OnRTLChange;
+
+        public event Action<Theme> OnThemeChange;
     }
 }


### PR DESCRIPTION
# Description
之前的行为：
在 `MApp` 组件初始化时，使用 `JS` 添加 `styles`，无法动态修改

修改后的行为：
在  `MApp` 组件内部添加内联CSS，即使预渲染状态下无法使用 `JS` ，也可以确保正确生成预配置样式
修改 `MasaBlazor` 服务的 `Theme ` 属性为可写，并添加 `Action` 通知 `MApp` 组件样式已修改，重新生成内联CSS

组件库的文档没有适配深色模式，我也不熟悉组件库文档站点，所以没有同步修改适配，还请见谅

Machine translation: 

previous behavior:
When the `MApp` component is initialized, `styles` are added with `JS` and cannot be modified dynamically

Modified behavior:
Adding inline CSS inside the `MApp` component ensures that preconfigured styles are generated correctly even if `JS` is not available in the pre-rendered state
Modify the `Theme` property of the `MasaBlazor` service to be writable, and add `Action` to notify the `MApp` component style has been modified and regenerate the inline CSS

The documentation of the component library does not adapt to dark mode, and I am not familiar with the component library documentation site, so I did not modify the adaptation synchronously, please forgive me

## Issue reference

#929 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation

It was not clear where the unit tests were, so it was not written
