### PR TITLE
refactor: change the way to toggle theme

### DIFF
--- a/docs/Masa.Blazor.Docs/Examples/components/application/DynamicallyModifyTheme.razor
+++ b/docs/Masa.Blazor.Docs/Examples/components/application/DynamicallyModifyTheme.razor
@@ -15,11 +15,7 @@
     public Task IsDarkChanged(bool isDark)
     {
         IsDark = isDark;
-        var theme = MasaBlazor.Theme;
-        theme.Dark = isDark;
-
-        MasaBlazor.Theme = theme;
-
+        MasaBlazor.ToggleTheme();
         return Task.CompletedTask;
     }
 }

--- a/docs/Masa.Blazor.Docs/Examples/components/application/DynamicallyModifyTheme.razor
+++ b/docs/Masa.Blazor.Docs/Examples/components/application/DynamicallyModifyTheme.razor
@@ -8,7 +8,7 @@
 
     protected override Task OnInitializedAsync()
     {
-        IsDark = MasaBlazor?.Theme?.Dark ?? false;
+        _isDark = MasaBlazor?.Theme?.Dark ?? false;
         return base.OnInitializedAsync();
     }
 

--- a/docs/Masa.Blazor.Docs/Examples/components/application/DynamicallyModifyTheme.razor
+++ b/docs/Masa.Blazor.Docs/Examples/components/application/DynamicallyModifyTheme.razor
@@ -4,7 +4,7 @@
     [Inject]
     public MasaBlazor MasaBlazor { get; set; }
 
-    bool IsDark { get; set; }
+    bool _isDark { get; set; }
 
     protected override Task OnInitializedAsync()
     {
@@ -12,10 +12,9 @@
         return base.OnInitializedAsync();
     }
 
-    public Task IsDarkChanged(bool isDark)
+    public void IsDarkChanged(bool isDark)
     {
         IsDark = isDark;
         MasaBlazor.ToggleTheme();
-        return Task.CompletedTask;
     }
 }

--- a/docs/Masa.Blazor.Docs/Examples/components/application/DynamicallyModifyTheme.razor
+++ b/docs/Masa.Blazor.Docs/Examples/components/application/DynamicallyModifyTheme.razor
@@ -1,4 +1,4 @@
-﻿<MSwitch Value="IsDark" TValue="bool" ValueChanged="IsDarkChanged" Label="@(IsDark?"Dark":"Light")"/>
+﻿<MSwitch Value="_isDark" TValue="bool" ValueChanged="IsDarkChanged" Label="@(_isDark?"Dark":"Light")"/>
 
 @code {
     [Inject]
@@ -14,7 +14,7 @@
 
     public void IsDarkChanged(bool isDark)
     {
-        IsDark = isDark;
+        _isDark = isDark;
         MasaBlazor.ToggleTheme();
     }
 }

--- a/docs/Masa.Blazor.Docs/wwwroot/pages/components/application/en-US.md
+++ b/docs/Masa.Blazor.Docs/wwwroot/pages/components/application/en-US.md
@@ -116,6 +116,6 @@ builder.Services.AddMasaBlazor(options =>
 
 ### Dynamically modify the theme
 
-You can access theme settings by referencing the app properties of the **Theme** object, or you can modify theme settings by reassigning values
+You can toggle theme by using the **ToggleTheme** method of the **MasaBlazor** service
 
 <masa-example file="Examples.components.application.DynamicallyModifyTheme"></masa-example>

--- a/docs/Masa.Blazor.Docs/wwwroot/pages/components/application/zh-CN.md
+++ b/docs/Masa.Blazor.Docs/wwwroot/pages/components/application/zh-CN.md
@@ -107,6 +107,6 @@ builder.Services.AddMasaBlazor(options =>
 
 ### 动态修改主题
 
-你可以通过引用 **Theme** 对象的应用属性来访问主题设置，也可以通过重新赋值来修改主题设置
+你可以通过 **MasaBlazor** 服务的 **ToggleTheme** 方法切换主题
 
 <masa-example file="Examples.components.application.DynamicallyModifyTheme"></masa-example>

--- a/src/Masa.Blazor/Services/MasaBlazor.cs
+++ b/src/Masa.Blazor/Services/MasaBlazor.cs
@@ -6,7 +6,6 @@
     public class MasaBlazor
     {
         private bool _rtl;
-        private Theme _theme;
 
         public MasaBlazor(Breakpoint breakpoint, Application application, Theme theme)
         {
@@ -32,19 +31,16 @@
 
         public Breakpoint Breakpoint { get; }
 
-        public Theme Theme
-        {
-            get { return _theme; }
-            set
-            {
-                _theme = value;
-                OnThemeChange?.Invoke(_theme);
-               
-            }
-        }
+        public Theme Theme { get; }
 
         public event Action<bool> OnRTLChange;
 
         public event Action<Theme> OnThemeChange;
+
+        public void ToggleTheme()
+        {
+            Theme.Dark = !Theme.Dark;
+            OnThemeChange?.Invoke(Theme);
+        }
     }
 }


### PR DESCRIPTION
已按照如下说明修改代码：

1. MasaBlazor.Theme 仍然是只读的。
2. MasaBlazor类下搞一个 public 的方法 ToggleTheme，把Theme的set的内容移入进去。
3. 主题的设置应该再 AddMasaBlazor 时就确定下来，不应该修改，MasaBlazor.Theme.Themes.Light.Primary = color 不应该支持。