### PR TITLE
fix:MAvatar component's Size property failure.

### DIFF
--- a/src/Masa.Blazor/Extensions/StyleBuilderExtensions.cs
+++ b/src/Masa.Blazor/Extensions/StyleBuilderExtensions.cs
@@ -94,7 +94,7 @@ namespace BlazorComponent
         private static StyleBuilder AddSize(this StyleBuilder styleBuilder, string name, StringNumber size)
         {
             return styleBuilder
-                        .AddIf(() => $"{name}: {size.ToUnit()}", () => size != null);
+                        .AddIf(() => $"{name}: {size.ToUnit()} !important", () => size != null);
         }
 
         public static StyleBuilder AddWidth(this StyleBuilder styleBuilder, StringNumber width)


### PR DESCRIPTION
设置MChip下的MAvatar的Size属性没用，会直接被外面的important覆盖掉
![企业微信截图_16789522308601](https://user-images.githubusercontent.com/38368335/225548933-51f8db51-964d-4f28-812e-5d271265caf6.png)
