### PR TITLE
🐛 fix(PageStack): prevent old page re-rendering after pushing

### DIFF
--- a/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStack.razor
+++ b/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStack.razor
@@ -18,12 +18,24 @@
         var index = i;
         var pageData = Pages.ElementAt(index);
         var isTop = i == Pages.Count - 1;
-        var canRender = isTop && NavigationManager.GetAbsolutePath().Equals(pageData.AbsolutePath, StringComparison.OrdinalIgnoreCase);
+        var shouldRender = isTop && NavigationManager.GetAbsolutePath().Equals(pageData.AbsolutePath, StringComparison.OrdinalIgnoreCase);
+
+        /*
+         * Even if shouldRender is false, ChildContent will be rendered on the first load.
+         * At this point, ChildContent may contain content from the previous page,
+         * causing unnecessary re-rendering.
+         * Only when shouldRender is true, we can ensure ChildContent is from the current page
+        */
+        if (shouldRender)
+        {
+            // Control the actual content rendering in PPageStackItem component by setting ReadyToRender flag
+            pageData.ReadyToRender = true;
+        }
 
         <PPageStackItem AppBarVisible="@AppBarAlwaysVisible"
                         DisableUnderlaySlide="@DisableUnderlaySlide"
                         Data="pageData"
-                        CanRender="@canRender"
+                        CanRender="@shouldRender"
                         OnGoBack="@HandleOnPrevious"
                         ChildContent="@ChildContent"
                         LoaderContent="@(LoaderContent ?? _defaultLoaderContent)"

--- a/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStackItem.razor
+++ b/src/Masa.Blazor.MobileComponents/Presets/PageStack/PPageStackItem.razor
@@ -12,7 +12,7 @@
          NoOutsideClick
          ContentAttributes="@(new Dictionary<string, object> { { "page-stack-id", Data.Id } })"
          @ref="_dialog">
-    @if (!_render)
+    @if (!(Data.ReadyToRender && _render))
     {
         @LoaderContent
     }

--- a/src/Masa.Blazor.MobileComponents/Presets/PageStack/StackPageData.cs
+++ b/src/Masa.Blazor.MobileComponents/Presets/PageStack/StackPageData.cs
@@ -34,6 +34,8 @@ public class StackPageData(string absolutePath, int id)
 
     public bool Active { get; private set; }
     
+    internal bool ReadyToRender { get; set; }
+    
     internal void UpdateState(object? state) => State = state;
 
     internal void UpdatePath(string absolutePath) => AbsolutePath = absolutePath;


### PR DESCRIPTION
循环PPageStackItem时，新页面第一次执行时，shouldRender即便是false, ChildContent也会被渲染，此时的ChildContent很可能是上一个页面的内容，导致上一个页面的内容重新渲染。只有当shouldRender为true时，才能确定ChildContent是新的页面内容。